### PR TITLE
検索入力にラベルを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,18 @@
 
       a { color: var(--accent-2); text-decoration: none; }
 
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
       .container {
         max-width: 1200px;
         margin: 0 auto;
@@ -356,6 +368,7 @@
 
       <div class="toolbar">
         <div class="search">
+          <label for="q" class="visually-hidden">検索</label>
           <input id="q" class="control" type="text" placeholder="検索（タイトル・本文・タグ）" />
         </div>
 


### PR DESCRIPTION
## Summary
- 検索欄に対応する`<label for="q">`を追加し、`visually-hidden`クラスで非表示化
- 非表示ラベル用の`visually-hidden`クラスをスタイルに追加

## Testing
- `npm test` (package.json が見つからないため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68b289fc14888329b728716325a9b98f